### PR TITLE
Fix server and extend askanythinghandler test 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ settings.py
 .DS_Store
 .cache
 ./databases/**
+env/

--- a/application.py
+++ b/application.py
@@ -7,6 +7,7 @@ import tornado.escape
 import tornado.ioloop
 import tornado.web
 from tornado.options import define, options
+import tornado.httpserver
 
 import src.aswwu.base_handlers as base
 import src.aswwu.route_handlers.ask_anything as ask_anything
@@ -88,13 +89,18 @@ class Application(tornado.web.Application):
 
 def start_server(tornado, io_loop):
     # create a new instance of our Application
+    global application
     application = Application()
-    application.listen(options.port)
+    global server
+    server = tornado.httpserver.HTTPServer(application)
+    server.listen(options.port)
+    # application.listen(options.port)
     # tell it to autoreload if anything changes
     tornado.autoreload.start()
     io_loop.start()
     print 'tornado server started'
 
 def stop_server(io_loop):
-    io_loop.stop()
+    io_loop.add_callback(io_loop.stop)
+    server.stop()
     print 'tornado server stopped'

--- a/application.py
+++ b/application.py
@@ -94,7 +94,6 @@ def start_server(tornado, io_loop):
     global server
     server = tornado.httpserver.HTTPServer(application)
     server.listen(options.port)
-    # application.listen(options.port)
     # tell it to autoreload if anything changes
     tornado.autoreload.start()
     io_loop.start()

--- a/src/aswwu/alchemy.py
+++ b/src/aswwu/alchemy.py
@@ -19,11 +19,12 @@ logger = logging.getLogger("aswwu")
 # import the necessary models (all of them in this case)
 
 # defines the databases URLs relative to "server.py"
-engine = create_engine("sqlite:///databases/people.db")
-archive_engine = create_engine("sqlite:///databases/archives.db")
-election_engine = create_engine("sqlite:///databases/senate_elections.db")
-pages_engine = create_engine("sqlite:///databases/pages.db")
-jobs_engine = create_engine("sqlite:///databases/jobs.db")
+# ?check_same_thread=False should only be a temp fix
+engine = create_engine("sqlite:///databases/people.db?check_same_thread=False")
+archive_engine = create_engine("sqlite:///databases/archives.db?check_same_thread=False")
+election_engine = create_engine("sqlite:///databases/senate_elections.db?check_same_thread=False")
+pages_engine = create_engine("sqlite:///databases/pages.db?check_same_thread=False")
+jobs_engine = create_engine("sqlite:///databases/jobs.db?check_same_thread=False")
 
 # create the model tables if they don't already exist
 Base.metadata.create_all(engine)

--- a/tests/aswwu/conftest.py
+++ b/tests/aswwu/conftest.py
@@ -1,0 +1,40 @@
+import pytest
+
+import threading
+
+import tornado.ioloop
+from tornado.options import define
+import application
+
+
+def start_testing_server():
+    # pass in the conf default name
+    conf_name = "default"
+
+    # initiate the IO loop for Tornado
+    io_loop = tornado.ioloop.IOLoop.instance()
+    tornado.options.parse_config_file("src/aswwu/" + conf_name + ".conf")
+
+    # create thread for running the server
+    thread = threading.Thread(
+        target=application.start_server, args=(tornado, io_loop))
+    thread.daemon = True
+    thread.start()
+
+    # allow server to start before running tests
+    import time
+    time.sleep(1)
+    print('starting services...')
+    return (io_loop, thread)
+
+
+def stop_testing_server(io_loop, thread):
+    application.stop_server(io_loop)
+    thread.join()
+
+
+@pytest.fixture()
+def testing_server():
+    (io_loop, thread) = start_testing_server()
+    yield
+    stop_testing_server(io_loop, thread)

--- a/tests/aswwu/test_AskAnythingViewAllHandler.py
+++ b/tests/aswwu/test_AskAnythingViewAllHandler.py
@@ -61,6 +61,34 @@ def test_db():
     conn.close()
 
 
+@pytest.fixture()
+def test_db_with_votes():
+    data = [(1, "2016-01-01 10:20:05.123", "Somthing", True, True),
+            (2, "2016-01-01 10:20:05.124", "Somthing Else", True, True),
+            (3, "2016-01-01 10:20:05.125", "Somthing More", True, True)]
+
+    data2 = [(1, "2016-01-01 10:20:05.126", 1, "ryan.rabello"),
+             (2, "2016-01-01 10:20:05.127", 2, "ryan.rabello"),
+             (3, "2016-01-01 10:20:05.128", 3, "ryan.rabello")]
+
+    conn = sqlite3.connect(
+        '/home/charlie/School/Fall_2017/Software_Testing/labs/python_server/databases/people.db'
+    )
+    with conn:
+        conn.executemany('INSERT INTO askanythings VALUES (?,?,?,?,?)', data)
+
+    with conn:
+        conn.executemany('INSERT INTO askanythingvotes VALUES (?,?,?,?)', data2)
+
+    yield
+    with conn:
+        conn.execute('DElETE FROM askanythings')
+
+    with conn:
+        conn.execute('DELETE FROM askanythingvotes')
+    conn.close()
+
+
 def test_No_Data(testing_server):
 
     expected_data = []
@@ -92,6 +120,36 @@ def test_Data(testing_server, test_db):
         u"question": u"Somthing More",
         u"authorized": True,
         u"has_voted": False,
+        u"question_id": u"3",
+    }]
+
+    url = "http://127.0.0.1:8888/askanything/view"
+    resp = requests.get(url)
+    assert (resp.status_code == 200)
+    assert (json.loads(resp.text) == expected_data)
+
+
+def test_Data_with_votes(testing_server, test_db_with_votes):
+    expected_data = [{
+        u"votes": 1,
+        u"reviewed": True,
+        u"question": u"Somthing",
+        u"authorized": True,
+        u"has_voted": True,
+        u"question_id": u"1",
+    }, {
+        u"votes": 1,
+        u"reviewed": True,
+        u"question": u"Somthing Else",
+        u"authorized": True,
+        u"has_voted": True,
+        u"question_id": u"2",
+    }, {
+        u"votes": 1,
+        u"reviewed": True,
+        u"question": u"Somthing More",
+        u"authorized": True,
+        u"has_voted": True,
         u"question_id": u"3",
     }]
 

--- a/tests/aswwu/test_AskAnythingViewAllHandler.py
+++ b/tests/aswwu/test_AskAnythingViewAllHandler.py
@@ -1,0 +1,101 @@
+import pytest
+import requests
+import json
+
+import threading
+
+import tornado.ioloop
+from tornado.options import define
+import sqlite3
+
+import application
+
+
+def start_testing_server():
+    # pass in the conf default name
+    conf_name = "default"
+
+    # initiate the IO loop for Tornado
+    io_loop = tornado.ioloop.IOLoop.instance()
+    tornado.options.parse_config_file("src/aswwu/" + conf_name + ".conf")
+
+    # create thread for running the server
+    thread = threading.Thread(
+        target=application.start_server, args=(tornado, io_loop))
+    thread.daemon = True
+    thread.start()
+
+    # allow server to start before running tests
+    import time
+    time.sleep(1)
+    print('starting services...')
+    return (io_loop, thread)
+
+
+def stop_testing_server(io_loop, thread):
+    application.stop_server(io_loop)
+    thread.join()
+
+
+@pytest.fixture()
+def testing_server():
+    (io_loop, thread) = start_testing_server()
+    yield
+    stop_testing_server(io_loop, thread)
+
+
+@pytest.fixture()
+def test_db():
+    data = [(1, "2016-01-01 10:20:05.123", "Somthing", True, True),
+            (2, "2016-01-01 10:20:05.124", "Somthing Else", True, True),
+            (3, "2016-01-01 10:20:05.125", "Somthing More", True, True)]
+
+    conn = sqlite3.connect(
+        '/home/charlie/School/Fall_2017/Software_Testing/labs/python_server/databases/people.db'
+    )
+    with conn:
+        conn.executemany('INSERT INTO askanythings VALUES (?,?,?,?,?)', data)
+    yield
+    with conn:
+        conn.execute('DElETE FROM askanythings')
+    conn.close()
+
+
+def test_No_Data(testing_server):
+
+    expected_data = []
+
+    url = "http://127.0.0.1:8888/askanything/view"
+    resp = requests.get(url)
+    assert (resp.status_code == 200)
+    assert (json.loads(resp.text) == expected_data)
+
+
+def test_Data(testing_server, test_db):
+    expected_data = [{
+        u"votes": 0,
+        u"reviewed": True,
+        u"question": u"Somthing",
+        u"authorized": True,
+        u"has_voted": False,
+        u"question_id": u"1",
+    }, {
+        u"votes": 0,
+        u"reviewed": True,
+        u"question": u"Somthing Else",
+        u"authorized": True,
+        u"has_voted": False,
+        u"question_id": u"2",
+    }, {
+        u"votes": 0,
+        u"reviewed": True,
+        u"question": u"Somthing More",
+        u"authorized": True,
+        u"has_voted": False,
+        u"question_id": u"3",
+    }]
+
+    url = "http://127.0.0.1:8888/askanything/view"
+    resp = requests.get(url)
+    assert (resp.status_code == 200)
+    assert (json.loads(resp.text) == expected_data)

--- a/tests/aswwu/test_AskAnythingViewAllHandler.py
+++ b/tests/aswwu/test_AskAnythingViewAllHandler.py
@@ -8,40 +8,6 @@ import tornado.ioloop
 from tornado.options import define
 import sqlite3
 
-import application
-
-
-def start_testing_server():
-    # pass in the conf default name
-    conf_name = "default"
-
-    # initiate the IO loop for Tornado
-    io_loop = tornado.ioloop.IOLoop.instance()
-    tornado.options.parse_config_file("src/aswwu/" + conf_name + ".conf")
-
-    # create thread for running the server
-    thread = threading.Thread(
-        target=application.start_server, args=(tornado, io_loop))
-    thread.daemon = True
-    thread.start()
-
-    # allow server to start before running tests
-    import time
-    time.sleep(1)
-    print('starting services...')
-    return (io_loop, thread)
-
-
-def stop_testing_server(io_loop, thread):
-    application.stop_server(io_loop)
-    thread.join()
-
-
-@pytest.fixture()
-def testing_server():
-    (io_loop, thread) = start_testing_server()
-    yield
-    stop_testing_server(io_loop, thread)
 
 
 @pytest.fixture()

--- a/tests/aswwu/test_AskAnythingViewAllHandler.py
+++ b/tests/aswwu/test_AskAnythingViewAllHandler.py
@@ -9,16 +9,13 @@ from tornado.options import define
 import sqlite3
 
 
-
 @pytest.fixture()
 def test_db():
     data = [(1, "2016-01-01 10:20:05.123", "Something", True, True),
             (2, "2016-01-01 10:20:05.124", "Something Else", True, True),
             (3, "2016-01-01 10:20:05.125", "Something More", True, True)]
 
-    conn = sqlite3.connect(
-        'databases/people.db'
-    )
+    conn = sqlite3.connect('databases/people.db', check_same_thread=False)
     with conn:
         conn.executemany('INSERT INTO askanythings VALUES (?,?,?,?,?)', data)
     yield
@@ -37,14 +34,13 @@ def test_db_with_votes():
              (2, "2016-01-01 10:20:05.127", 2, "ryan.rabello"),
              (3, "2016-01-01 10:20:05.128", 3, "ryan.rabello")]
 
-    conn = sqlite3.connect(
-        'databases/people.db'
-    )
+    conn = sqlite3.connect('databases/people.db', check_same_thread=False)
     with conn:
         conn.executemany('INSERT INTO askanythings VALUES (?,?,?,?,?)', data)
 
     with conn:
-        conn.executemany('INSERT INTO askanythingvotes VALUES (?,?,?,?)', data2)
+        conn.executemany('INSERT INTO askanythingvotes VALUES (?,?,?,?)',
+                         data2)
 
     yield
     with conn:

--- a/tests/aswwu/test_AskAnythingViewAllHandler.py
+++ b/tests/aswwu/test_AskAnythingViewAllHandler.py
@@ -1,11 +1,6 @@
 import pytest
 import requests
 import json
-
-import threading
-
-import tornado.ioloop
-from tornado.options import define
 import sqlite3
 
 

--- a/tests/aswwu/test_AskAnythingViewAllHandler.py
+++ b/tests/aswwu/test_AskAnythingViewAllHandler.py
@@ -17,7 +17,7 @@ def test_db():
             (3, "2016-01-01 10:20:05.125", "Something More", True, True)]
 
     conn = sqlite3.connect(
-        '/home/charlie/School/Fall_2017/Software_Testing/labs/python_server/databases/people.db'
+        'databases/people.db'
     )
     with conn:
         conn.executemany('INSERT INTO askanythings VALUES (?,?,?,?,?)', data)

--- a/tests/aswwu/test_AskAnythingViewAllHandler.py
+++ b/tests/aswwu/test_AskAnythingViewAllHandler.py
@@ -12,9 +12,9 @@ import sqlite3
 
 @pytest.fixture()
 def test_db():
-    data = [(1, "2016-01-01 10:20:05.123", "Somthing", True, True),
-            (2, "2016-01-01 10:20:05.124", "Somthing Else", True, True),
-            (3, "2016-01-01 10:20:05.125", "Somthing More", True, True)]
+    data = [(1, "2016-01-01 10:20:05.123", "Something", True, True),
+            (2, "2016-01-01 10:20:05.124", "Something Else", True, True),
+            (3, "2016-01-01 10:20:05.125", "Something More", True, True)]
 
     conn = sqlite3.connect(
         '/home/charlie/School/Fall_2017/Software_Testing/labs/python_server/databases/people.db'
@@ -29,16 +29,16 @@ def test_db():
 
 @pytest.fixture()
 def test_db_with_votes():
-    data = [(1, "2016-01-01 10:20:05.123", "Somthing", True, True),
-            (2, "2016-01-01 10:20:05.124", "Somthing Else", True, True),
-            (3, "2016-01-01 10:20:05.125", "Somthing More", True, True)]
+    data = [(1, "2016-01-01 10:20:05.123", "Something", True, True),
+            (2, "2016-01-01 10:20:05.124", "Something Else", True, True),
+            (3, "2016-01-01 10:20:05.125", "Something More", True, True)]
 
     data2 = [(1, "2016-01-01 10:20:05.126", 1, "ryan.rabello"),
              (2, "2016-01-01 10:20:05.127", 2, "ryan.rabello"),
              (3, "2016-01-01 10:20:05.128", 3, "ryan.rabello")]
 
     conn = sqlite3.connect(
-        '/home/charlie/School/Fall_2017/Software_Testing/labs/python_server/databases/people.db'
+        'databases/people.db'
     )
     with conn:
         conn.executemany('INSERT INTO askanythings VALUES (?,?,?,?,?)', data)
@@ -69,21 +69,21 @@ def test_Data(testing_server, test_db):
     expected_data = [{
         u"votes": 0,
         u"reviewed": True,
-        u"question": u"Somthing",
+        u"question": u"Something",
         u"authorized": True,
         u"has_voted": False,
         u"question_id": u"1",
     }, {
         u"votes": 0,
         u"reviewed": True,
-        u"question": u"Somthing Else",
+        u"question": u"Something Else",
         u"authorized": True,
         u"has_voted": False,
         u"question_id": u"2",
     }, {
         u"votes": 0,
         u"reviewed": True,
-        u"question": u"Somthing More",
+        u"question": u"Something More",
         u"authorized": True,
         u"has_voted": False,
         u"question_id": u"3",
@@ -99,21 +99,21 @@ def test_Data_with_votes(testing_server, test_db_with_votes):
     expected_data = [{
         u"votes": 1,
         u"reviewed": True,
-        u"question": u"Somthing",
+        u"question": u"Something",
         u"authorized": True,
         u"has_voted": True,
         u"question_id": u"1",
     }, {
         u"votes": 1,
         u"reviewed": True,
-        u"question": u"Somthing Else",
+        u"question": u"Something Else",
         u"authorized": True,
         u"has_voted": True,
         u"question_id": u"2",
     }, {
         u"votes": 1,
         u"reviewed": True,
-        u"question": u"Somthing More",
+        u"question": u"Something More",
         u"authorized": True,
         u"has_voted": True,
         u"question_id": u"3",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+import threading
+import tornado.ioloop
+import application
+
+
+def start_testing_server():
+    # pass in the conf default name
+    conf_name = "default"
+
+    # initiate the IO loop for Tornado
+    io_loop = tornado.ioloop.IOLoop.instance()
+    tornado.options.parse_config_file("src/aswwu/" + conf_name + ".conf")
+
+    # create thread for running the server
+    thread = threading.Thread(
+        target=application.start_server, args=(tornado, io_loop))
+    thread.daemon = True
+    thread.start()
+
+    # allow server to start before running tests
+    import time
+    time.sleep(1)
+    return (io_loop, thread)
+
+
+def stop_testing_server(io_loop, thread):
+    application.stop_server(io_loop)
+    # Close the thread
+    thread.join()
+
+
+@pytest.fixture()
+def testing_server():
+    (io_loop, thread) = start_testing_server()
+    yield
+    stop_testing_server(io_loop, thread)

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,81 +1,66 @@
 # test_system.py
-import pytest
-import unittest
 import requests
 import json
 
-import threading
 
-import tornado.ioloop
-from tornado.options import define
+def test_root(testing_server):
+    expected_data = {
+        "username": "ryan.rabello",
+        "wwuid": "919428746",
+        "roles": "",
+        "photo": "profiles/1718/00958-2019687.jpg",
+        "status": None,
+        "full_name": "Ryan Rabello"
+    }
 
-import application
+    url = 'http://127.0.0.1:8888/'
+    resp = requests.get(url)
+    assert (resp.status_code == 200)
+    assert (json.loads(resp.text) == expected_data)
 
-def start_testing_server():
-    # pass in the conf default name
-    conf_name = "default"
 
-    # initiate the IO loop for Tornado
-    global io_loop
-    io_loop = tornado.ioloop.IOLoop.instance()
-    tornado.options.parse_config_file("src/aswwu/"+conf_name+".conf")
+def test_search_all(testing_server):
+    expected_data = {
+        "results": [{
+            "username": "john.doe",
+            "photo": "profiles/1718/00958-2019687.jpg",
+            "email": "",
+            "full_name": "John Doe",
+            "views": "6"
+        }, {
+            "username": "ryan.rabello",
+            "photo": "profiles/1718/00958-2019687.jpg",
+            "email": "ryan.rabello@wallawalla.edu",
+            "full_name": "Ryan Rabello",
+            "views": "9"
+        }, {
+            "username": "jane.anderson",
+            "photo": "profiles/1718/00958-2019687.jpg",
+            "email": "",
+            "full_name": "Jane Anderson",
+            "views": "8"
+        }, {
+            "username": "michael.scott",
+            "photo": "None",
+            "email": "None",
+            "full_name": "Michael Scott",
+            "views": "0"
+        }, {
+            "username": "mary.johnson",
+            "photo": "profiles/1718/00958-2019687.jpg",
+            "email": "",
+            "full_name": "Mary Johnson",
+            "views": "6"
+        }, {
+            "username": "susan.brown",
+            "photo": "profiles/1718/00958-2019687.jpg",
+            "email": "",
+            "full_name": "Susan Brown",
+            "views": "18"
+        }]
+    }
 
-    # create thread for running the server
-    global thread
-    thread = threading.Thread(target=application.start_server, args=(tornado, io_loop))
-    thread.daemon = True
-    thread.start()
-
-    # allow server to start before running tests
-    import time
-    time.sleep(1)
-    print('starting services...')
-
-def stop_testing_server():
-    application.stop_server(io_loop)
-    thread.join()
-
-class test_system(unittest.TestCase):
-    @classmethod
-    def setup_class(cls):
-        start_testing_server()
-        print("setup_class()")
-
-    @classmethod
-    def teardown_class(cls):
-        stop_testing_server()
-        print("teardown_class()")
-
-    @staticmethod
-    def test_root():
-        expected_data = {
-                "username": "ryan.rabello",
-                "wwuid": "919428746",
-                "roles": "",
-                "photo": "profiles/1718/00958-2019687.jpg",
-                "status": None,
-                "full_name": "Ryan Rabello"
-            }
-
-        url = 'http://127.0.0.1:8888/'
-        resp = requests.get(url)
-        assert(resp.status_code == 200)
-        assert(json.loads(resp.text) == expected_data)
-
-    @staticmethod
-    def test_search_all():
-        expected_data = {
-                "results": [
-                        {"username": "john.doe", "photo": "profiles/1718/00958-2019687.jpg", "email": "", "full_name": "John Doe", "views": "6"},
-                        {"username": "ryan.rabello", "photo": "profiles/1718/00958-2019687.jpg", "email": "ryan.rabello@wallawalla.edu", "full_name": "Ryan Rabello", "views": "9"},
-                        {"username": "jane.anderson", "photo": "profiles/1718/00958-2019687.jpg", "email": "", "full_name": "Jane Anderson", "views": "8"},
-                        {"username": "michael.scott", "photo": "None", "email": "None", "full_name": "Michael Scott", "views": "0"},
-                        {"username": "mary.johnson", "photo": "profiles/1718/00958-2019687.jpg", "email": "", "full_name": "Mary Johnson", "views": "6"},
-                        {"username": "susan.brown", "photo": "profiles/1718/00958-2019687.jpg", "email": "", "full_name": "Susan Brown", "views": "18"}
-                ]
-        };
-
-        url = 'http://127.0.0.1:8888/search/all'
-        resp = requests.get(url)
-        assert(resp.status_code == 200)
-        assert(json.loads(resp.text) == expected_data)
+    url = 'http://127.0.0.1:8888/search/all'
+    resp = requests.get(url)
+    assert (resp.status_code == 200)
+    assert (json.loads(resp.text) == expected_data)

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -21,6 +21,7 @@ def start_testing_server():
     tornado.options.parse_config_file("src/aswwu/"+conf_name+".conf")
 
     # create thread for running the server
+    global thread
     thread = threading.Thread(target=application.start_server, args=(tornado, io_loop))
     thread.daemon = True
     thread.start()
@@ -32,6 +33,7 @@ def start_testing_server():
 
 def stop_testing_server():
     application.stop_server(io_loop)
+    thread.join()
 
 class test_system(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
I fixed the server code, which was creating an HTTP server via the .listen() convenience function but was not closing the server properly on teardown. I explicitly called the server creation and closure as well as closing the thread properly.

I created a pytest test fixture that mimics the first server tests setup and teardown action, it is listed in the conftest.py.

I created a few tests for the AskAnythingViewAllHandler.